### PR TITLE
Integrate training program models

### DIFF
--- a/migrations/0001_initial.py
+++ b/migrations/0001_initial.py
@@ -1,0 +1,53 @@
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='TrainingProgram',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=255)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+                ('coach', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='programs', to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='TrainingDay',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('day_number', models.PositiveIntegerField()),
+                ('program', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='days', to='WiseFittapp.trainingprogram')),
+            ],
+        ),
+        migrations.CreateModel(
+            name='TrainingBlock',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('title', models.CharField(max_length=100)),
+                ('block_type', models.CharField(choices=[('warmup', 'Warm-Up'), ('strength', 'Strength'), ('conditioning', 'Conditioning'), ('accessory', 'Accessory'), ('mobility', 'Mobility')], max_length=30)),
+                ('day', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='blocks', to='WiseFittapp.trainingday')),
+            ],
+        ),
+        migrations.CreateModel(
+            name='TrainingExerciseBlock',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=255)),
+                ('sets', models.CharField(max_length=10)),
+                ('reps', models.CharField(max_length=10)),
+                ('tempo', models.CharField(blank=True, max_length=20)),
+                ('rest', models.CharField(blank=True, max_length=20)),
+                ('notes', models.TextField(blank=True)),
+                ('block', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='exercises', to='WiseFittapp.trainingblock')),
+            ],
+        ),
+    ]

--- a/models.py
+++ b/models.py
@@ -1,1 +1,47 @@
-# Paste your models.py code here manually from the canvas.
+
+from django.db import models
+from django.contrib.auth.models import User
+
+# Categorias de bloco
+BLOCK_TYPES = [
+    ("warmup", "Warm-Up"),
+    ("strength", "Strength"),
+    ("conditioning", "Conditioning"),
+    ("accessory", "Accessory"),
+    ("mobility", "Mobility")
+]
+
+class TrainingProgram(models.Model):
+    name = models.CharField(max_length=255)
+    coach = models.ForeignKey(User, on_delete=models.CASCADE, related_name="programs")
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self):
+        return self.name
+
+class TrainingDay(models.Model):
+    program = models.ForeignKey(TrainingProgram, on_delete=models.CASCADE, related_name="days")
+    day_number = models.PositiveIntegerField()
+
+    def __str__(self):
+        return f"{self.program.name} - Day {self.day_number}"
+
+class TrainingBlock(models.Model):
+    day = models.ForeignKey(TrainingDay, on_delete=models.CASCADE, related_name="blocks")
+    title = models.CharField(max_length=100)
+    block_type = models.CharField(max_length=30, choices=BLOCK_TYPES)
+
+    def __str__(self):
+        return f"{self.block_type.upper()} - {self.title}"
+
+class TrainingExerciseBlock(models.Model):
+    block = models.ForeignKey(TrainingBlock, on_delete=models.CASCADE, related_name="exercises")
+    name = models.CharField(max_length=255)
+    sets = models.CharField(max_length=10)
+    reps = models.CharField(max_length=10)
+    tempo = models.CharField(max_length=20, blank=True)
+    rest = models.CharField(max_length=20, blank=True)
+    notes = models.TextField(blank=True)
+
+    def __str__(self):
+        return self.name

--- a/settings.py
+++ b/settings.py
@@ -37,6 +37,9 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'rest_framework',
+    'rest_framework.authtoken',
+    'WiseFittapp',
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
## Summary
- add training program models from `trainheroic_sgpt_system.zip`
- register rest framework and app in `INSTALLED_APPS`
- provide initial migration for new models

## Testing
- `pytest -q`
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_684acb9897f8832b8fc4418da2f426b2